### PR TITLE
Serialization test with various sub-second precision

### DIFF
--- a/src/test/groovy/stix/bundle/BundleSpec.groovy
+++ b/src/test/groovy/stix/bundle/BundleSpec.groovy
@@ -7,6 +7,8 @@ import io.digitalstate.stix.bundle.BundleObject
 import io.digitalstate.stix.json.StixParsers
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
+
+import spock.lang.IgnoreRest
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -46,4 +48,21 @@ class BundleSpec extends Specification implements StixMockDataGenerator {
         where:
             i << (1..100) // More tests are run because of the large variation of probabilities and number of combinations
     }
+	
+	@IgnoreRest
+	def "parse Indicator Bundle"(){
+		
+		when:"setup file access to bundle"
+
+		String bundleJson = getClass()
+                .getResource("/stix/baseline/json/sdo/indicator/indicators.json").getText("UTF-8")
+
+		then: "Parse json into bundle"
+		Bundle bundle = (Bundle)StixParsers.parseBundle(bundleJson)
+		println bundle.inspect()
+		println bundle.toJsonString()
+
+		and: "the original bundle json matches the parsed object that was converted back to json"
+		assert mapper.readTree(bundle.toJsonString()) == mapper.readTree(bundleJson)
+	}
 }

--- a/src/test/resources/stix/baseline/json/sdo/indicator/indicators.json
+++ b/src/test/resources/stix/baseline/json/sdo/indicator/indicators.json
@@ -1,0 +1,43 @@
+{
+	"type": "bundle",
+	"id": "bundle--6fab341c-36c5-4a7f-be29-0a6e3b85e7b0",
+	"spec_version": "2.0",
+	"objects": [
+		{
+			"type": "indicator",
+			"id": "indicator--59ccb738-921a-4941-8ab2-33da522bd4e1", 
+			"created": "2019-04-08T22:59:50.0Z",
+			"modified": "2019-04-08T22:59:50.00Z",
+		     "labels": [
+		       "malicious-activity"
+		     ],
+			"name": "128.0.0.1",
+			"pattern": "[ipv4-addr:value = '128.0.0.1']", 
+			"valid_from": "2019-04-08T22:59:50.000Z"
+		},
+		{
+			"type": "indicator",
+			"id": "indicator--350db038-43ef-4445-a79e-1c33fbe7b279", 
+			"created": "2019-04-08T22:59:50.1234Z",
+			"modified": "2019-04-08T22:59:50.1234Z",
+		    "labels": [
+		      "malicious-activity"
+		    ],
+			"name": "192.168.74.1",
+			"pattern": "[ipv4-addr:value = '192.168.74.1']", 
+			"valid_from": "2019-04-08T22:59:50.543Z"
+		},
+		{
+			"type": "indicator",
+			"id": "indicator--a8be7bfe-a9bc-417f-b52b-95edec5c03d6", 
+			"created": "2019-04-08T22:59:50.123400000Z",
+		    "labels": [
+		      "malicious-activity"
+		    ],
+			"modified": "2019-04-08T22:59:50.Z",
+			"name": "10.0.1.12",
+			"pattern": "[ipv4-addr:value = '10.0.1.12']", 
+			"valid_from": "2019-04-08T22:59:50.Z"		
+		}
+	]
+}


### PR DESCRIPTION
Here is a test of indicators with various sub-second precision in timestamp fields.  They do parse and print out correctly, however, the serialization does drop trailing zeros.