### PR TITLE
created TLP classes as defined in spec

### DIFF
--- a/src/main/java/io/digitalstate/stix/datamarkings/objects/Tlps.java
+++ b/src/main/java/io/digitalstate/stix/datamarkings/objects/Tlps.java
@@ -1,0 +1,80 @@
+/**
+ * 
+ */
+package io.digitalstate.stix.datamarkings.objects;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import io.digitalstate.stix.common.StixInstant;
+import io.digitalstate.stix.datamarkings.MarkingDefinition;
+
+/**
+ * @author Kathy Lee Simunich, Argonne National Laboratory
+ *
+ */
+public class Tlps {
+    
+    
+	public static final MarkingDefinition TLP_WHITE = Tlps.getTlpWhiteMD();
+	public static final MarkingDefinition TLP_GREEN = Tlps.getTlpGreenMD();
+	public static final MarkingDefinition TLP_AMBER = Tlps.getTlpAmberMD();
+	public static final MarkingDefinition TLP_RED = Tlps.getTlpRedMD();
+
+    
+	/**
+	 * Factory methods to create the known types
+	 */
+	private static MarkingDefinition getTlpWhiteMD() {
+        MarkingDefinition.Builder builder = MarkingDefinition.builder()
+        		.id("marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9")
+        		.definitionType("tlp")
+        		.created(new StixInstant(ZonedDateTime.parse("2017-01-20T00:00:00.000Z", DateTimeFormatter.ISO_DATE_TIME).toInstant(),3))
+        		.definition(Tlp.builder()
+        					.tlp("white")
+        					.build());
+
+		return builder.build();
+
+	}
+	
+	private static MarkingDefinition getTlpGreenMD() {
+        MarkingDefinition.Builder builder = MarkingDefinition.builder()
+        		.id("marking-definition--34098fce-860f-48ae-8e50-ebd3cc5e41da")
+        		.definitionType("tlp")
+        		.created(new StixInstant(ZonedDateTime.parse("2017-01-20T00:00:00.000Z", DateTimeFormatter.ISO_DATE_TIME).toInstant(),3))
+        		.definition(Tlp.builder()
+        					.tlp("green")
+        					.build());
+
+		return builder.build();
+
+	}
+
+	private static MarkingDefinition getTlpAmberMD() {
+        MarkingDefinition.Builder builder = MarkingDefinition.builder()
+        		.id("marking-definition--f88d31f6-486f-44da-b317-01333bde0b82")
+        		.definitionType("tlp")
+        		.created(new StixInstant(ZonedDateTime.parse("2017-01-20T00:00:00.000Z", DateTimeFormatter.ISO_DATE_TIME).toInstant(),3))
+        		.definition(Tlp.builder()
+        					.tlp("amber")
+        					.build());
+
+		return builder.build();
+
+	}
+
+	private static MarkingDefinition getTlpRedMD() {
+        MarkingDefinition.Builder builder = MarkingDefinition.builder()
+        		.id("marking-definition--5e57c739-391a-4eb3-b6be-7d15ca92d5ed")
+        		.definitionType("tlp")
+        		.created(new StixInstant(ZonedDateTime.parse("2017-01-20T00:00:00.000Z", DateTimeFormatter.ISO_DATE_TIME).toInstant(),3))
+        		.definition(Tlp.builder()
+        					.tlp("red")
+        					.build());
+
+		return builder.build();
+
+	}
+
+}

--- a/src/test/groovy/stix/datamarkings/TLPmarkingsSpec.groovy
+++ b/src/test/groovy/stix/datamarkings/TLPmarkingsSpec.groovy
@@ -1,0 +1,96 @@
+/**
+ * 
+ */
+package stix.datamarkings
+
+import org.skyscreamer.jsonassert.JSONAssert
+import org.skyscreamer.jsonassert.JSONCompareMode
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+
+import io.digitalstate.stix.common.StixInstant
+import io.digitalstate.stix.datamarkings.MarkingDefinition
+import io.digitalstate.stix.datamarkings.objects.Tlps
+import io.digitalstate.stix.json.StixParsers
+import io.digitalstate.stix.sdo.objects.Indicator
+import spock.lang.Shared
+import spock.lang.Specification
+
+/**
+ * @author Kathy Lee Simunich, Argonne National Laboratory
+ *
+ */
+class TLPmarkingsSpec extends Specification {
+	
+	@Shared ObjectMapper mapper = new ObjectMapper()
+	
+	
+	def "test TLP"() {
+		when: "create tlp white"
+		
+		MarkingDefinition originalMarkingDefinition = Tlps.TLP_WHITE;
+		
+        then: "Convert Marking Definition to Json"
+            JsonNode originalJson = mapper.readTree(originalMarkingDefinition.toJsonString())
+            String originalJsonString = mapper.writeValueAsString(originalJson)
+            println "Original Json: ${originalJsonString}"
+
+        then: "Parse Json back into Marking Definition Object"
+            MarkingDefinition parsedMarkingDefinition = (MarkingDefinition)StixParsers.parseObject(originalJsonString)
+            println "Parsed Object: ${parsedMarkingDefinition}"
+
+        //@TODO needs to be setup to handle dehydrated object comparison
+//        then: "Parsed object should match Original object"
+//            assert originalMarkingDefinition == parsedMarkingDefinition
+
+        then: "Convert Parsed Marking Definition Object back to into Json"
+            JsonNode newJson =  mapper.readTree(parsedMarkingDefinition.toJsonString())
+            String newJsonString = mapper.writeValueAsString(newJson)
+            println "New Json: ${newJsonString}"
+
+        then: "New Json should match Original Json"
+            JSONAssert.assertEquals(originalJsonString, newJsonString, JSONCompareMode.NON_EXTENSIBLE)
+	
+	}
+	
+	def "test indicator with TLP marking"() {
+		when: "create tlp green"
+		
+		MarkingDefinition green = Tlps.TLP_GREEN;
+		StixInstant now = new StixInstant();
+		
+		Indicator ind = Indicator.builder()
+						.id("indicator--59ccb738-921a-4941-8ab2-33da522bd4e1")
+						.created(now)
+						.modified(now)
+						.labels(Arrays.asList("malicious-activity"))
+						.name("128.0.0.1")
+						.pattern("[ipv4-addr:value = '128.0.0.1']")
+						.validFrom(now)
+						.objectMarkingRefs(Arrays.asList(green))
+						.build();
+		
+		then: "Convert Marking Definition to Json"
+			JsonNode originalJson = mapper.readTree(ind.toJsonString())
+			String originalJsonString = mapper.writeValueAsString(originalJson)
+			println "Original Json: ${originalJsonString}"
+
+		then: "Parse Json back into Marking Definition Object"
+			Indicator parsed = (Indicator)StixParsers.parseObject(originalJsonString)
+			println "Parsed Object: ${parsed}"
+
+		//@TODO needs to be setup to handle dehydrated object comparison
+//        then: "Parsed object should match Original object"
+//            assert originalMarkingDefinition == parsedMarkingDefinition
+
+		then: "Convert Parsed Marking Definition Object back to into Json"
+			JsonNode newJson =  mapper.readTree(parsed.toJsonString())
+			String newJsonString = mapper.writeValueAsString(newJson)
+			println "New Json: ${newJsonString}"
+
+		then: "New Json should match Original Json"
+			JSONAssert.assertEquals(originalJsonString, newJsonString, JSONCompareMode.NON_EXTENSIBLE)
+	
+	}
+}


### PR DESCRIPTION
The STIX spec defines the exact ID and created date for the 4 TLP markings.  I defined them in a class as static values and created a test Spec.  It's interesting that the markings do not need to be within the bundle.

Note that the Stix Mocking for TLP Marking defs makes up custom properties, but they are not really allowed for the TLP markings.