### PR TITLE
Support for Generic Custom STIX Object

### DIFF
--- a/src/main/java/io/digitalstate/stix/bundle/BundleableObject.java
+++ b/src/main/java/io/digitalstate/stix/bundle/BundleableObject.java
@@ -2,6 +2,7 @@ package io.digitalstate.stix.bundle;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.digitalstate.stix.common.Stix;
+import io.digitalstate.stix.custom.objects.CustomObject;
 import io.digitalstate.stix.datamarkings.GranularMarkingDm;
 import io.digitalstate.stix.datamarkings.MarkingDefinitionDm;
 
@@ -13,7 +14,7 @@ import java.util.Set;
  * Thus the name "BundleableObject".  A Bundleable Object by STIX standard is: SDO, SRO, and Marking Definition.
  * The Type field is used to determine the sub-types as registered in the {@link io.digitalstate.stix.json.StixParsers}
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", include = JsonTypeInfo.As.EXISTING_PROPERTY)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", include = JsonTypeInfo.As.EXISTING_PROPERTY, visible = true, defaultImpl = CustomObject.class)
 public interface BundleableObject extends Serializable, Stix {
 
     String getType();

--- a/src/main/java/io/digitalstate/stix/common/StixCommonProperties.java
+++ b/src/main/java/io/digitalstate/stix/common/StixCommonProperties.java
@@ -28,7 +28,7 @@ import java.util.Set;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
 
 /**
- * Base interface used by Immutable STIX Domain Objects
+ * Base interface used by Immutable STIX Bundleable Objects
  */
 @Value.Style(validationMethod = Value.Style.ValidationMethod.NONE)
 public interface StixCommonProperties extends StixSpecVersion, SdoDefaultValidator, BundleableObject {

--- a/src/main/java/io/digitalstate/stix/common/StixCustomObjectId.java
+++ b/src/main/java/io/digitalstate/stix/common/StixCustomObjectId.java
@@ -1,0 +1,28 @@
+package io.digitalstate.stix.common;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import io.digitalstate.stix.redaction.Redactable;
+import io.digitalstate.stix.validation.contraints.startswith.StartsWith;
+import io.digitalstate.stix.validation.groups.ValidateIdOnly;
+import org.immutables.value.Value;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.groups.Default;
+
+/**
+ *
+ */
+@Value.Style(validationMethod = Value.Style.ValidationMethod.NONE)
+public interface StixCustomObjectId {
+
+    @JsonProperty("id")
+    @JsonPropertyDescription("Represents identifiers across the CTI specifications. The format consists of the name of the top-level object being identified, followed by two dashes (--), followed by a UUIDv4.")
+    @Pattern(regexp = "^[a-z][a-z-]+[a-z]--[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+    @NotBlank(groups = {Default.class, ValidateIdOnly.class}, message = "Id is required")
+    @StartsWith("x-")
+    String getId();
+
+}

--- a/src/main/java/io/digitalstate/stix/common/StixCustomObjectType.java
+++ b/src/main/java/io/digitalstate/stix/common/StixCustomObjectType.java
@@ -1,0 +1,28 @@
+package io.digitalstate.stix.common;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import io.digitalstate.stix.validation.contraints.startswith.StartsWith;
+import io.digitalstate.stix.validation.groups.ValidateIdOnly;
+import org.immutables.value.Value;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+import javax.validation.groups.Default;
+
+/**
+ *
+ */
+@Value.Style(validationMethod = Value.Style.ValidationMethod.NONE)
+public interface StixCustomObjectType {
+
+    @JsonProperty("type")
+    @JsonPropertyDescription("The type property identifies the type of STIX Object (SDO, Relationship Object, etc). The value of the type field MUST be one of the types defined by a STIX Object (e.g., indicator).")
+    @Pattern(regexp = "^\\-?[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\\-?$")
+    @Size(min = 3, max = 250)
+    @NotBlank(groups = {Default.class, ValidateIdOnly.class}, message = "Type is required1")
+    @StartsWith("x-")
+    String getType();
+
+}

--- a/src/main/java/io/digitalstate/stix/custom/StixCustomObject.java
+++ b/src/main/java/io/digitalstate/stix/custom/StixCustomObject.java
@@ -2,17 +2,11 @@ package io.digitalstate.stix.custom;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import io.digitalstate.stix.common.*;
 import io.digitalstate.stix.validation.contraints.startswith.StartsWith;
-import io.digitalstate.stix.validation.groups.ValidateIdOnly;
 import org.hibernate.validator.constraints.Length;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
-import javax.validation.groups.Default;
 import java.util.Map;
 
 /**
@@ -23,7 +17,7 @@ public interface StixCustomObject extends
         StixCommonProperties,
         StixLabels,
         StixModified,
-        StixRevoked {
+        StixRevoked{
 
     @Override
     @StartsWith("x-")

--- a/src/main/java/io/digitalstate/stix/custom/StixCustomObject.java
+++ b/src/main/java/io/digitalstate/stix/custom/StixCustomObject.java
@@ -1,0 +1,44 @@
+package io.digitalstate.stix.custom;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import io.digitalstate.stix.common.*;
+import io.digitalstate.stix.validation.contraints.startswith.StartsWith;
+import io.digitalstate.stix.validation.groups.ValidateIdOnly;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+import javax.validation.groups.Default;
+import java.util.Map;
+
+/**
+ * Provides a Generic STIX Custom Object to use for Bundleable objects when the object is not included in the mappings.
+ * Note: Custom properties (x_) are included in the CustomObjectProperties
+ */
+public interface StixCustomObject extends
+        StixCommonProperties,
+        StixLabels,
+        StixModified,
+        StixRevoked {
+
+    @Override
+    @StartsWith("x-")
+    String getType();
+
+    @Override
+    @StartsWith("x-")
+    String getId();
+
+    //@TODO Future enhancement to create a custom deserializer that will support the difference between x_ props and the CustomObjectProperties()
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    @JsonUnwrapped @JsonAnyGetter
+    Map<@Length(min = 3,
+            max = 250,
+            message = "STIX Custom Properties must have a min key length of 3 and max of 250")
+            String, Object> getCustomObjectProperties();
+
+}

--- a/src/main/java/io/digitalstate/stix/custom/objects/GenericCustomObject.java
+++ b/src/main/java/io/digitalstate/stix/custom/objects/GenericCustomObject.java
@@ -1,0 +1,25 @@
+package io.digitalstate.stix.custom.objects;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.digitalstate.stix.bundle.BundleableObject;
+import io.digitalstate.stix.custom.StixCustomObject;
+import io.digitalstate.stix.validation.contraints.defaulttypevalue.DefaultTypeValue;
+import io.digitalstate.stix.validation.groups.DefaultValuesProcessor;
+import org.immutables.serial.Serial;
+import org.immutables.value.Value;
+
+
+@Value.Immutable @Serial.Version(1L)
+//@DefaultTypeValue(value = "", groups = {DefaultValuesProcessor.class})
+@Value.Style(typeAbstract="Generic*", typeImmutable="*", validationMethod = Value.Style.ValidationMethod.NONE, additionalJsonAnnotations = {JsonTypeName.class}, depluralize = true)
+@JsonSerialize(as = CustomObject.class) @JsonDeserialize(builder = CustomObject.Builder.class)
+@JsonPropertyOrder({"type", "id", "created_by_ref", "created",
+        "modified", "revoked", "labels", "external_references",
+        "object_marking_refs", "granular_markings"})
+public interface GenericCustomObject extends StixCustomObject {
+
+
+}

--- a/src/main/java/io/digitalstate/stix/json/StixParsers.java
+++ b/src/main/java/io/digitalstate/stix/json/StixParsers.java
@@ -1,5 +1,7 @@
 package io.digitalstate.stix.json;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
@@ -141,7 +143,7 @@ public class StixParsers {
         }
     }
 
-        public static <T extends Stix> Stix parse(String bundleJsonString, Class<T> stixClass) throws IOException, StixParserValidationException {
+        public static <T extends Stix> T parse(String bundleJsonString, Class<T> stixClass) throws IOException, StixParserValidationException {
         try {
             return getJsonMapper().readValue(bundleJsonString, stixClass);
         } catch (IOException ex) {

--- a/src/test/groovy/stix/custom/CustomObjectSpec.groovy
+++ b/src/test/groovy/stix/custom/CustomObjectSpec.groovy
@@ -1,15 +1,10 @@
 package stix.custom
 
-import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
-import faker.StixMockDataGenerator
 import io.digitalstate.stix.bundle.BundleableObject
 import io.digitalstate.stix.custom.StixCustomObject
 import io.digitalstate.stix.custom.objects.CustomObject
 import io.digitalstate.stix.json.StixParsers
-import io.digitalstate.stix.sdo.objects.AttackPattern
-import org.skyscreamer.jsonassert.JSONAssert
-import org.skyscreamer.jsonassert.JSONCompareMode
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -22,31 +17,14 @@ class CustomObjectSpec extends Specification {
     def "Generic Object Test 1"() {
         when: "Attempt to Parse a custom object"
             String jsonString = getClass().getResource("/stix/custom/custom_object_1.json").getText("UTF-8")
-        StixCustomObject originalObject = (StixCustomObject)StixParsers.parseObject(jsonString)
-        CustomObject originalObjectGeneric = StixParsers.parse(jsonString, CustomObject.class)
-//            println "Original Object: ${originalAttackPattern.toString()}"
 
         then:
-            println originalObject
-//        then: "Convert Attack Pattern to Json"
-//            JsonNode originalJson = mapper.readTree(originalAttackPattern.toJsonString())
-//            String originalJsonString = mapper.writeValueAsString(originalJson)
-////            println "Original Json: ${originalJsonString}"
-//
-//        then: "Parse Json back into Attack Pattern Object"
-//            AttackPattern parsedAttackPattern = (AttackPattern)StixParsers.parseObject(originalJsonString)
-////            println "Parsed Object: ${parsedAttackPattern}"
-//
-//        //@TODO needs to be setup to handle dehydrated object comparison
-////        then: "Parsed object should match Original object"
-////            assert originalAttackPattern == parsedAttackPattern
-//
-//        then: "Convert Parsed Attack Pattern Object back to into Json"
-//            JsonNode newJson =  mapper.readTree(parsedAttackPattern.toJsonString())
-//            String newJsonString = mapper.writeValueAsString(newJson)
-////            println "New Json: ${newJsonString}"
-//
-//        then: "New Json should match Original Json"
-//            JSONAssert.assertEquals(originalJsonString, newJsonString, JSONCompareMode.NON_EXTENSIBLE)
+            StixCustomObject originalObject = (StixCustomObject)StixParsers.parseObject(jsonString)
+            StixCustomObject originalObjectGeneric = StixParsers.parse(jsonString, CustomObject.class)
+            BundleableObject bundleableObject = StixParsers.parse(jsonString, BundleableObject.class)
+//            println originalObject
+//            println originalObjectGeneric
+//            println bundleableObject
+//            println "********"
     }
 }

--- a/src/test/groovy/stix/custom/CustomObjectSpec.groovy
+++ b/src/test/groovy/stix/custom/CustomObjectSpec.groovy
@@ -1,0 +1,52 @@
+package stix.custom
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import faker.StixMockDataGenerator
+import io.digitalstate.stix.bundle.BundleableObject
+import io.digitalstate.stix.custom.StixCustomObject
+import io.digitalstate.stix.custom.objects.CustomObject
+import io.digitalstate.stix.json.StixParsers
+import io.digitalstate.stix.sdo.objects.AttackPattern
+import org.skyscreamer.jsonassert.JSONAssert
+import org.skyscreamer.jsonassert.JSONCompareMode
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class CustomObjectSpec extends Specification {
+
+    @Shared ObjectMapper mapper = new ObjectMapper()
+
+    @Unroll
+    def "Generic Object Test 1"() {
+        when: "Attempt to Parse a custom object"
+            String jsonString = getClass().getResource("/stix/custom/custom_object_1.json").getText("UTF-8")
+        StixCustomObject originalObject = (StixCustomObject)StixParsers.parseObject(jsonString)
+        CustomObject originalObjectGeneric = StixParsers.parse(jsonString, CustomObject.class)
+//            println "Original Object: ${originalAttackPattern.toString()}"
+
+        then:
+            println originalObject
+//        then: "Convert Attack Pattern to Json"
+//            JsonNode originalJson = mapper.readTree(originalAttackPattern.toJsonString())
+//            String originalJsonString = mapper.writeValueAsString(originalJson)
+////            println "Original Json: ${originalJsonString}"
+//
+//        then: "Parse Json back into Attack Pattern Object"
+//            AttackPattern parsedAttackPattern = (AttackPattern)StixParsers.parseObject(originalJsonString)
+////            println "Parsed Object: ${parsedAttackPattern}"
+//
+//        //@TODO needs to be setup to handle dehydrated object comparison
+////        then: "Parsed object should match Original object"
+////            assert originalAttackPattern == parsedAttackPattern
+//
+//        then: "Convert Parsed Attack Pattern Object back to into Json"
+//            JsonNode newJson =  mapper.readTree(parsedAttackPattern.toJsonString())
+//            String newJsonString = mapper.writeValueAsString(newJson)
+////            println "New Json: ${newJsonString}"
+//
+//        then: "New Json should match Original Json"
+//            JSONAssert.assertEquals(originalJsonString, newJsonString, JSONCompareMode.NON_EXTENSIBLE)
+    }
+}

--- a/src/test/resources/stix/custom/custom_object_1.json
+++ b/src/test/resources/stix/custom/custom_object_1.json
@@ -1,0 +1,16 @@
+{
+  "external_references": [
+    {
+      "external_id": "TA0006",
+      "source_name": "mitre-attack",
+      "url": "https://attack.mitre.org/tactics/TA0006"
+    }
+  ],
+  "id": "x-mitre-tactic--2558fd61-8c75-4730-94c4-11926db2a263",
+  "name": "Credential Access",
+  "created": "2018-10-17T00:14:20.652Z",
+  "modified": "2018-10-17T00:14:20.652Z",
+  "type": "x-mitre-tactic",
+  "description": "Credential access represents techniques resulting in access to or control over system, domain, or service credentials that are used within an enterprise environment. Adversaries will likely attempt to obtain legitimate credentials from users or administrator accounts (local system administrator or domain users with administrator access) to use within the network. This allows the adversary to assume the identity of the account, with all of that account's permissions on the system and network, and makes it harder for defenders to detect the adversary. With sufficient access within a network, an adversary can create accounts for later use within the environment.",
+  "x_mitre_shortname": "credential-access"
+}


### PR DESCRIPTION
Adds support for generic custom stix object that can capture any non-class defined object.

This ensures that if you are parsing a bundle with a bundleable object that you do not have a class for, then it will still parse as expected into this generic custom stix object class.